### PR TITLE
Fix broken divide_segment test

### DIFF
--- a/test/divide_segment.test.js
+++ b/test/divide_segment.test.js
@@ -6,7 +6,7 @@ var Queue         = require('tinyqueue');
 var load          = require('load-json-file');
 var martinez      = require('../src/');
 var SweepEvent    = require('../src/sweep_event');
-var compareEvents = require('../src/compare_events').compare;
+var compareEvents = require('../src/compare_events');
 var intersection  = require('../src/segment_intersection');
 var equals        = require('../src/equals');
 
@@ -61,19 +61,19 @@ tap.test('divide segments', function (main) {
 
     var e = q.pop();
     t.strictSame(e.point, [100.79403384562251, 233.41363754101192]);
-    t.strictSame(e.otherEvent.point, [153, 203.5]);
-
-    e = q.pop();
-    t.strictSame(e.point, [100.79403384562251, 233.41363754101192]);
     t.strictSame(e.otherEvent.point, [56, 181]);
 
     e = q.pop();
     t.strictSame(e.point, [100.79403384562251, 233.41363754101192]);
-    t.strictSame(e.otherEvent.point, [153, 294.5]);
+    t.strictSame(e.otherEvent.point, [16, 282]);
 
     e = q.pop();
     t.strictSame(e.point, [100.79403384562251, 233.41363754101192]);
-    t.strictSame(e.otherEvent.point, [16, 282]);
+    t.strictSame(e.otherEvent.point, [153, 203.5]);
+
+    e = q.pop();
+    t.strictSame(e.point, [100.79403384562251, 233.41363754101192]);
+    t.strictSame(e.otherEvent.point, [153, 294.5]);
 
     t.end();
   });


### PR DESCRIPTION
The "possible intersections" test in divide_segments.test.js is broken because the compare_events function is incorrectly required, and so the priority queue uses the default ordering since it is undefined.