### PR TITLE
Fix rounding errors

### DIFF
--- a/src/segment_intersection.js
+++ b/src/segment_intersection.js
@@ -94,7 +94,15 @@ module.exports = function (a1, a2, b1, b2, noEndpointTouch) {
       // not on line segment b
       return null;
     }
-    return noEndpointTouch ? null : [toPoint(a1, s, va)];
+    if (s === 0 || s === 1) {
+      // on an endpoint of line segment a
+      return noEndpointTouch ? null : [toPoint(a1, s, va)];
+    }
+    if (t === 0 || t === 1) {
+      // on an endpoint of line segment b
+      return noEndpointTouch ? null : [toPoint(b1, t, vb)];
+    }
+    return [toPoint(a1, s, va)];
   }
 
   // If we've reached this point, then the lines are either parallel or the

--- a/test/edge_cases.test.js
+++ b/test/edge_cases.test.js
@@ -141,7 +141,7 @@ tap.test('Edge cases', function(main) {
         subject.geometry.coordinates,
         clipping.geometry.coordinates
       );
-      t.deepEqual(result, [[[[-1883,-8.5],[-1783,-8.5],[-1783,-3],[-1783,-2.999999999999999],[-1883,-3],[-1883,-8.5]]]]);
+      t.deepEqual(result, [[[[-1883,-8.5],[-1783,-8.5],[-1783,-3],[-1883,-3],[-1883,-8.5]]]]);
 
       t.end();
     });
@@ -151,7 +151,7 @@ tap.test('Edge cases', function(main) {
         subject.geometry.coordinates,
         clipping.geometry.coordinates
       );
-      t.deepEqual(result, [[[[-1883,-25],[-1783,-25],[-1783,-8.5],[-1783,-3],[-1783,-2.999999999999999],[-1783,75],[-1883,75],[-1883,-3],[-1883,-8.5],[-1883,-25]]]]);
+      t.deepEqual(result, [[[[-1883,-25],[-1783,-25],[-1783,-8.5],[-1783,-3],[-1783,75],[-1883,75],[-1883,-3],[-1883,-8.5],[-1883,-25]]]]);
 
       t.end();
     });

--- a/test/segment_intersection.test.js
+++ b/test/segment_intersection.test.js
@@ -7,6 +7,7 @@ tap.test('intersection', function (t) {
 
   t.strictSame(intersection([0, 0], [1, 1], [1, 0], [2, 2]), null, 'null if no intersections');
   t.strictSame(intersection([0, 0], [1, 1], [1, 0], [10, 2]), null, 'null if no intersections');
+  t.strictSame(intersection([2, 2], [3, 3], [0, 6], [2, 4]), null, 'null if no intersections');
 
   t.strictSame(intersection([0, 0], [1, 1], [1, 0], [0, 1]), [[0.5, 0.5]], '1 intersection');
   t.strictSame(intersection([0, 0], [1, 1], [0, 1], [0, 0]), [[0, 0]], 'shared point 1');
@@ -35,6 +36,8 @@ tap.test('intersection', function (t) {
 
   t.strictSame(intersection([0, 0], [1, 1], [0, 0], [1, 1], true), null, 'full overlap, skip touches');
   t.strictSame(intersection([1, 1], [0, 0], [0, 0], [1, 1], true), null, 'full overlap, orientation, skip touches');
+
+  t.strictSame(intersection([0, 0], [1, 1], [1, 0], [0, 1], true), [[0.5, 0.5]], '1 intersection, skip touches');
 
   t.end();
 });


### PR DESCRIPTION
In working on #58, I noticed [two of the test cases](https://github.com/w8r/martinez/blob/v0.3.3/test/edge_cases.test.js#L144) each have an extra point in their expected result to compensate for rounding errors. Instead of just a point at `[-1783,-3]`, they each have two points: `[-1783,-3]` and `[-1783,-2.999999999999999]`.

This PR fixes that issue.

In looking into that, I found out that the [intersect function](https://github.com/w8r/martinez/blob/v0.3.3/src/segment_intersection.js#L49) is being overzealous in applying the `noEndpointTouch` option - ie. returning null in cases when the intersection is not an endpoint of either line. That situation isn't being exercised by the test suite. This PR adds test cases for that and fixes that issue as well.

Again, thanks for you all for your work on martinez, very very helpful. Let me know if there's any tweaks you'd like to see to this PR. Cheers.