### PR TITLE
Fix rounding error between triangle area calculation and intersection calculation

### DIFF
--- a/src/signed_area.js
+++ b/src/signed_area.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var intersection  = require('./segment_intersection');
+
 /**
  * Signed area of the triangle (p0, p1, p2)
  * @param  {Array.<Number>} p0
@@ -8,5 +10,8 @@
  * @return {Number}
  */
 module.exports = function signedArea(p0, p1, p2) {
+  // avoid rounding error b/t intersection calculation and triangle area calc
+  var inters = intersection(p0, p1, p0, p2)
+  if (inters.length === 2) return 0
   return (p0[0] - p2[0]) * (p1[1] - p2[1]) - (p1[0] - p2[0]) * (p0[1] - p2[1]);
 };

--- a/test/edge_cases.test.js
+++ b/test/edge_cases.test.js
@@ -218,6 +218,31 @@ tap.test('Edge cases', function(main) {
     t.end();
   });
 
+  main.test('no rounding error between intersection calculation and triangle area', (t) => {
+    const p1 = [[
+      [-62.8, -41],
+      [-63.0001099, -41.1121599],
+      [-62.93564, -41.0940399],
+      [-62.8, -41]
+    ]];
+    const p2 =[[
+      [-62.8, -41.2],
+      [-62.8, -41],
+      [-62.964969880531925, -41.10228339712406],
+      [-63.0001099, -41.1121599],
+      [-62.8, -41.2]
+    ]];
+    const expected = [[[
+      [-63.0001099, -41.1121599],
+      [-62.964969880531925, -41.10228339712406],
+      [-62.8, -41],
+      [-63.0001099, -41.1121599]
+    ]]]
+
+    t.deepEqual(martinez.diff(p1, p2), expected)
+    t.end();
+  });
+
   main.test('collapsed edges removed', (t) => {
     const p1 = [[
       [355,139],


### PR DESCRIPTION
Currently, both the triangle area calculation in `signed_area.js` and the intersection calculation in `segment_intersection.js` are used to determine if two line segments are collinear. A signed area of 0 indicates collinearity, while a intersection calculation of 2 also indicates collinearity.

Segment intersection is used [here](https://github.com/w8r/martinez/blob/v0.3.3/src/possible_intersection.js#L20) while signed area is used [here](https://github.com/w8r/martinez/blob/v0.3.3/src/compare_segments.js#L17) and [here](https://github.com/w8r/martinez/blob/v0.3.3/src/compare_events.js#L39).

It's possible (due to rounding errors) for the signed area calculation to return a non-zero result (indicating the segments are *not* collinear) while for the same two line segments, the intersection calculation will calculate two intersections (indicating the segments *are* collinear). When this happens, segments can get inserted into the sweep line but never removed - messing up order of segments in the sweep line which in turn messes up the calculation of whether other line segments should be included in the final result or not.

This PR adds a test case demonstrating that sutiation, and implements a fix.