### PR TITLE
Replace avl

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "watchify": "^3.7.0"
   },
   "dependencies": {
-    "avl": "^1.4.1",
+    "splaytree": "^0.1.1",
     "tinyqueue": "^1.2.0"
   }
 }

--- a/src/subdivide_segments.js
+++ b/src/subdivide_segments.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Tree                 = require('avl');
+var Tree                 = require('splaytree');
 var computeFields        = require('./compute_fields');
 var possibleIntersection = require('./possible_intersection');
 var compareSegments      = require('./compare_segments');

--- a/test/compare_segments.test.js
+++ b/test/compare_segments.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var tap             = require('tap');
-var Tree            = require('avl');
+var Tree            = require('splaytree');
 var compareSegments = require('../src/compare_segments');
 var compareEvents   = require('../src/compare_events');
 var SweepEvent      = require('../src/sweep_event');

--- a/test/divide_segment.test.js
+++ b/test/divide_segment.test.js
@@ -17,7 +17,7 @@ var possibleIntersection = require('../src/possible_intersection');
 // GeoJSON Data
 var shapes = load.sync(path.join(__dirname, 'fixtures', 'two_shapes.geojson'));
 
-var Tree = require('avl');
+var Tree = require('splaytree');
 var compareSegments = require('../src/compare_segments');
 
 var subject = shapes.features[0];

--- a/test/sweep_line.test.js
+++ b/test/sweep_line.test.js
@@ -2,7 +2,7 @@
 
 var tap             = require('tap');
 var path            = require('path');
-var Tree            = require('avl');
+var Tree            = require('splaytree');
 var load            = require('load-json-file');
 var compareSegments = require('../src/compare_segments');
 var SweepEvent      = require('../src/sweep_event');


### PR DESCRIPTION
Simple replacement of avl with splaytree. Benchmark results below - it looks like splaytree is faster on smaller geometries but only a minor difference on larger geometries

With splaytree
````
Hole_Hole
Martinez x 18,000 ops/sec ±0.67% (93 runs sampled)
JSTS x 1,400 ops/sec ±39.48% (89 runs sampled)
- Fastest is Martinez

Asia union
Martinez x 6.77 ops/sec ±8.74% (22 runs sampled)
JSTS x 6.24 ops/sec ±6.07% (20 runs sampled)
- Fastest is Martinez

States clip
Martinez x 160 ops/sec ±2.93% (74 runs sampled)
JSTS x 87.08 ops/sec ±0.44% (73 runs sampled)
- Fastest is Martinez
````

With AVL
````
Hole_Hole
Martinez x 13,745 ops/sec ±0.91% (90 runs sampled)
JSTS x 1,720 ops/sec ±6.04% (90 runs sampled)
- Fastest is Martinez

Asia union
Martinez x 7.74 ops/sec ±4.60% (24 runs sampled)
JSTS x 6.64 ops/sec ±3.54% (21 runs sampled)
- Fastest is Martinez

States clip
Martinez x 164 ops/sec ±1.99% (83 runs sampled)
JSTS x 85.35 ops/sec ±1.73% (73 runs sampled)
- Fastest is Martinez
````
