### PR TITLE
Added loop guard to loops that have a dynamic exit condition.

### DIFF
--- a/src/connect_edges.js
+++ b/src/connect_edges.js
@@ -3,6 +3,7 @@
 // var equals = require('./equals');
 var compareEvents = require('./compare_events');
 var operationType = require('./operation');
+var createLoopGuard = require('./create_loop_guard');
 
 /**
  * @param  {Array.<SweepEvent>} sortedEvents
@@ -118,7 +119,9 @@ module.exports = function connectEdges(sortedEvents, operation) {
     var initial = resultEvents[i].point;
     contour[0].push(initial);
 
+    var innerLoopGuard = createLoopGuard(resultEvents.length * 10, 'connectEdges() inner loop');
     while (pos >= i) {
+      innerLoopGuard.check();
       event = resultEvents[pos];
       processed[pos] = true;
 

--- a/src/create_loop_guard.js
+++ b/src/create_loop_guard.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/** Create an object that tracks the number of times a loop is iterated and throws an error if the
+ *  iteration count exceeds the specified maximum.
+ *
+ *  @param {Number} maxIterations Max number of loop iterations before an error is thrown.
+ *  @param {String} locationDescription Optional location that will be added to message of a thrown error.
+ *  @return {Object} An object with a check() member that should be called once on each loop iteration. Caller
+ *                   should not share or reuse this object instance--create a fresh one each time a loop is
+ *                   entered.
+ */
+module.exports = function createLoopGuard(maxIterations, locationDescription) {
+  return {
+    iterationCount: 0,
+    check: function () {
+      var locationConcat;
+      if (++this.iterationCount > maxIterations) {
+        locationConcat = locationDescription ? ' in ' + locationDescription : '';
+        throw new Error('Surpassed ' + maxIterations + ' iterations' + locationConcat + '.');
+      }
+    }
+  };
+};

--- a/src/subdivide_segments.js
+++ b/src/subdivide_segments.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Tree                 = require('avl');
+var createLoopGuard      = require('./create_loop_guard');
 var computeFields        = require('./compute_fields');
 var possibleIntersection = require('./possible_intersection');
 var compareSegments      = require('./compare_segments');
@@ -18,7 +19,9 @@ module.exports = function subdivide(eventQueue, subject, clipping, sbbox, cbbox,
   var INTERSECTION = operations.INTERSECTION;
   var DIFFERENCE   = operations.DIFFERENCE;
 
+  var eventQueueGuard = createLoopGuard(eventQueue.length * 10, 'subdivide() event queue');
   while (eventQueue.length) {
+    eventQueueGuard.check();
     var event = eventQueue.pop();
     sortedEvents.push(event);
 

--- a/test/create_loop_guard.test.js
+++ b/test/create_loop_guard.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var tap             = require('tap');
+var createLoopGuard = require('../src/create_loop_guard');
+
+tap.test('create loop guard', (main) => {
+
+  main.test('creates a loop guard object', (t) => {
+    t.type(createLoopGuard(10), 'object');
+    t.end();
+  });
+
+  main.test('does not throw if iterated less than max iterations', (t) => {
+    var loopGuard = createLoopGuard(10);
+    loopGuard.check();
+    t.end();
+  });
+
+  main.test('does not throw if iterated exactly max iterations', (t) => {
+    var i, loopGuard = createLoopGuard(10);
+    for (i = 0; i < 10; ++i) { loopGuard.check(); }
+    t.end();
+  });
+
+  main.test('throws if iterated one past max iterations', (t) => {
+    var i, loopGuard = createLoopGuard(10);
+    for (i = 0; i < 10; ++i) { loopGuard.check(); }
+    t.throws(function () { loopGuard.check(); });
+    t.end();
+  });
+
+  main.test('throws with a location description', (t) => {
+    var didItThrow = false;
+    var loopGuard = createLoopGuard(0, 'my location');
+    try {
+      loopGuard.check();
+    } catch (err) {
+      didItThrow = true;
+      t.ok(err.message.includes('my location'));
+    }
+    t.ok(didItThrow);
+    t.end();
+  });
+
+  main.end();
+});


### PR DESCRIPTION
Please see #63 for the rationale behind this.

There were just two loops in the code that have a dynamic exit condition. I didn't see any reason to guard the other loops, because they have a constant exit condition, so their behavior is easily predictable. Of the two places where a guard is added in this PR, only the inner loop of ```connectEdges()``` has generated infinite loops that I'm aware of. There could be some fundamental change made to the loop code where we are 100% sure it will never inf-loop, but this guard will keep browsers from crashing until that time. Have tested this successfully on the known cases that I reported.