### PR TITLE
Add browser to package.json to help webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.1",
   "description": "Martinez polygon clipping algorithm, does boolean operation on polygons (multipolygons, polygons with holes etc): intersection, union, difference, xor",
   "main": "dist/martinez.umd.js",
+  "browser": "dist/martinez.umd.js",
   "module": "index",
   "jsnext:main": "index",
   "types": "index.d.ts",


### PR DESCRIPTION
Webpack 3 prioritizes the "module" entry of the package.json ahead of "main". This causes the webpack build to break during minify: https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify

If the "browser" entry is added, webpack 3 prioritizes it over "module". This allows systems that expect ES Modules to find them via "module" while support for all browsers is exposed through "browser".

(Discovered while making fix for https://github.com/Turfjs/turf/issues/1400. This is needed to allow `martinez-polygon-clipping` to build with default `create-react-app` settings, which many projects would use.)