### PR TITLE
Prevent nextPos for connectEdges from accessing past end of array.

### DIFF
--- a/src/connect_edges.js
+++ b/src/connect_edges.js
@@ -75,7 +75,8 @@ function nextPos(pos, resultEvents, processed, origIndex) {
     } else   {
       newPos++;
     }
-    p1 = resultEvents[newPos].point;
+    if (newPos < length)
+      p1 = resultEvents[newPos].point;
   }
 
   newPos = pos - 1;


### PR DESCRIPTION
I am not certain whether this is a consequence of my previous bug fix, independent of that bug fix, or a revealed bug from that bug fix. In any case, the code prior to this fix was a bit sketchy since the top of the loop was checking that the incrementing variable was less than length of the array but the code inside the loop could already have used that variable to index into the array (which is where this crash was occurring). The change here is simply to only access the array if the index is less than the length.

I did not add an additional test case as my datasets that were triggering this bug are large and I needed to do some significant work to cull them down.