### PR TITLE
Fixes operation export

### DIFF
--- a/dist/martinez.min.js
+++ b/dist/martinez.min.js
@@ -1,5 +1,5 @@
 /**
- * martinez v0.6.0
+ * martinez v0.6.1
  * Martinez polygon clipping algorithm, does boolean operation on polygons (multipolygons, polygons with holes etc): intersection, union, difference, xor
  *
  * @author Alex Milevski <info@w8r.name>

--- a/dist/martinez.umd.js
+++ b/dist/martinez.umd.js
@@ -1,5 +1,5 @@
 /**
- * martinez v0.6.0
+ * martinez v0.6.1
  * Martinez polygon clipping algorithm, does boolean operation on polygons (multipolygons, polygons with holes etc): intersection, union, difference, xor
  *
  * @author Alex Milevski <info@w8r.name>

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "martinez-polygon-clipping",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Martinez polygon clipping algorithm, does boolean operation on polygons (multipolygons, polygons with holes etc): intersection, union, difference, xor",
   "main": "dist/martinez.umd.js",
   "browser": "dist/martinez.umd.js",
-  "module": "src/index",
-  "jsnext:main": "src/index",
+  "module": "index.js",
+  "jsnext:main": "index.js",
   "files": [
     "index.d.ts",
     "src/",


### PR DESCRIPTION
Apparently, that was broken in the environments that would go for `module` field in the `package.json`
```js
import { union } from 'martinez-polygon-clipping';

console.log(typeof union); // 'undefined';
```
or wouldn't build at all.
This PR addresses that