### PR TITLE
Fixed order of computeFields recomputations

### DIFF
--- a/src/subdivide_segments.js
+++ b/src/subdivide_segments.js
@@ -41,7 +41,7 @@ export default function subdivide(eventQueue, subject, clipping, sbbox, cbbox, o
       if (next) {
         if (possibleIntersection(event, next.key, eventQueue) === 2) {
           computeFields(event, prevEvent, operation);
-          computeFields(event, next.key, operation);
+          computeFields(next.key, event, operation);
         }
       }
 

--- a/test/genericTestCases/issue124.geojson
+++ b/test/genericTestCases/issue124.geojson
@@ -1,0 +1,32 @@
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [[[0, 10], [0, -10], [30, -10], [30, 10], [0, 10]]],
+        "type": "Polygon"
+      },
+      "properties": {},
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [[[10, 10], [10, -10], [20, -10], [20, 10], [10, 10]]],
+        "type": "Polygon"
+      },
+      "properties": {},
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [[[0, -10], [10, -10], [10, 10], [0, 10], [0, -10]]],
+          [[[20, -10], [30, -10], [30, 10], [20, 10], [20, -10]]]
+        ],
+        "type": "MultiPolygon"
+      },
+      "properties": {"operation": "diff"},
+      "type": "Feature"
+    }
+  ],
+  "type": "FeatureCollection"
+}


### PR DESCRIPTION
#124 seems to be caused by an issue I encountered recently. In the case of a segment overlap (`possibleIntersection` returns 2), the algorithm needs to re-run `computeFields`.

My understanding of this logic is: If there is an overlap with `next`, the sweep line order is:
```
next
event
prevEvent
```
In order to recompute the fields correctly from bottom to top, the recompute fields should be:
- recompute `event` based on `prevEvent`
- recompute `next` based on `event`

Basically the operands of the second call were swapped so far.

For comparison this is exactly how it is done in the overlap with `prev` case. Here the sweep line order is:
```
event
prevEvent
prevprevEvent
```
With the recompute fields call order:
- recompute `prevEvent` based on `prevprevEvent`
- recompute `event` based on `prevEvent`

The test case now works properly:

![image](https://user-images.githubusercontent.com/3620703/77820969-9999bd80-70e6-11ea-84ba-c207c4d84238.png)
