### PR TITLE
flip transition if swapping between hole & exterior

### DIFF
--- a/src/connect_edges.js
+++ b/src/connect_edges.js
@@ -96,7 +96,12 @@ function initializeContourFromContext(event, contours, contourId) {
     // in an earlier iteration, otherwise it wouldn't be possible that it is "previous in
     // result".
     const lowerContourId = prevInResult.outputContourId;
-    const lowerResultTransition = prevInResult.resultTransition;
+    let lowerResultTransition = prevInResult.resultTransition;
+
+    if (!event.isExteriorRing && prevInResult.isExteriorRing) {
+      lowerResultTransition = 1;
+    }
+
     if (lowerResultTransition > 0) {
       // We are inside. Now we have to check if the thing below us is another hole or
       // an exterior contour.


### PR DESCRIPTION
Resolves https://github.com/w8r/martinez/issues/128

When constructing one of the output contours it starts a contour, the first `event` for the contour is part of the interior ring, while the `event.prevInResult` is from the exterior ring, nowhere near the `event`... I'm not quite sure how that happens.

This PR adds a check to try and make sure the interior ring get's written to the correct spot.