### PR TITLE
Simplify types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import boolean from "./src/";
 import { INTERSECTION, DIFFERENCE, UNION, XOR } from "./src/operation";
-import type { Geometry } from "./src/types";
+import type { Geometry, MultiPolygon } from "./src/types";
 
 export type {
   Position,
@@ -10,22 +10,22 @@ export type {
   Geometry,
 } from "./src/types";
 
-export function union(subject: Geometry, clipping: Geometry): Geometry | null {
+export function union(subject: Geometry, clipping: Geometry): MultiPolygon | null {
   return boolean(subject, clipping, UNION);
 }
 
-export function diff(subject: Geometry, clipping: Geometry): Geometry | null {
+export function diff(subject: Geometry, clipping: Geometry): MultiPolygon | null {
   return boolean(subject, clipping, DIFFERENCE);
 }
 
-export function xor(subject: Geometry, clipping: Geometry): Geometry | null {
+export function xor(subject: Geometry, clipping: Geometry): MultiPolygon | null {
   return boolean(subject, clipping, XOR);
 }
 
 export function intersection(
   subject: Geometry,
   clipping: Geometry
-): Geometry | null {
+): MultiPolygon | null {
   return boolean(subject, clipping, INTERSECTION);
 }
 


### PR DESCRIPTION
[`boolean()`](https://github.com/w8r/martinez/blob/00e08d222cc0f87f12a6fc71ade26bbe6e89a78e/src/index.ts#L56) function always returns `MultiPolygon` but the public API provides it like `Polygon | MultiPolygon`, making a client guess what exact result is actually returned.